### PR TITLE
Added JSON reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Flags (all optional):
     	 text = creates a text file in current directory with basic information
     	  csv = creates a csv file in current directory with detailed information
     	print = just prints the report without creating any file
+       json = creates a JSON file in the current directory with detailed information
     	 (default "text")
   -parallelism uint
     	extent of parallelism (defaults to number of cores minus 1)

--- a/entity/file_digest.go
+++ b/entity/file_digest.go
@@ -7,9 +7,9 @@ import (
 
 // FileDigest contains properties of a file that makes the file unique to a very high degree of confidence
 type FileDigest struct {
-	FileExtension string
-	FileSize      int64
-	FileHash      string
+	FileExtension string `json:"ext"`
+	FileSize      int64  `json:"size"`
+	FileHash      string `json:"hash"`
 }
 
 func (f FileDigest) String() string {

--- a/entity/output_mode.go
+++ b/entity/output_mode.go
@@ -5,6 +5,7 @@ const (
 	OutputModeCsvFile  = "csv"
 	OutputModeTextFile = "text"
 	OutputModeStdOut   = "print"
+	OutputModeJSON     = "json"
 )
 
 // OutputModes and their brief descriptions
@@ -12,4 +13,5 @@ var OutputModes = map[string]string{
 	OutputModeTextFile: "creates a text file in current directory with basic information",
 	OutputModeCsvFile:  "creates a csv file in current directory with detailed information",
 	OutputModeStdOut:   "just prints the report without creating any file",
+	OutputModeJSON:     "creates a JSON file in the current directory with detailed information",
 }

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ const (
 	exitCodeErrorCreatingReport
 	exitCodeInvalidOutputMode
 	exitCodeReportFileCreationFailed
+	exitCodeWritingToReportFileFailed
 )
 
 //go:embed default_exclusions.txt
@@ -220,7 +221,12 @@ func main() {
 	}
 	fmte.Printf("Found %d duplicates. A total of %s can be saved by removing them.\n",
 		duplicateTotalCount, bytesutil.BinaryFormat(savingsSize))
-	reportDuplicates(duplicates, outputMode, allFiles, runID, reportFileName)
+
+	err := reportDuplicates(duplicates, outputMode, allFiles, runID, reportFileName)
+	if err != nil {
+		fmte.PrintfErr("error while reporting to file: %+v\n", err)
+		os.Exit(exitCodeWritingToReportFileFailed)
+	}
 }
 
 func createReportFileIfApplicable(runID string, outputMode string) (reportFileName string) {
@@ -231,6 +237,8 @@ func createReportFileIfApplicable(runID string, outputMode string) (reportFileNa
 		reportFileName = fmt.Sprintf("./duplicates_%s.csv", runID)
 	} else if outputMode == entity.OutputModeTextFile {
 		reportFileName = fmt.Sprintf("./duplicates_%s.txt", runID)
+	} else if outputMode == entity.OutputModeJSON {
+		reportFileName = fmt.Sprintf("./duplicates_%s.json", runID)
 	}
 	_, err := os.Create(reportFileName)
 	if err != nil {


### PR DESCRIPTION
With this change duplicates can be reported in JSON.

Usage,
```
go-find-duplicates -output json /home/adrian/photos/
```

Sample JSON file,
```
[
  {
    "ext": ".jpg",
    "size": 210381,
    "hash": "s0de88c66",
    "paths": [
      "/home/adrian/photos/IMG_9765.jpg",
      "/home/adrian/photos/IMG_9753.jpg"
    ]
  },
  {
    "ext": ".mp4",
    "size": 1067501,
    "hash": "sda3d7cfb",
    "paths": [
      "/home/adrian/photos/VID_1234.mp4",
      "/home/adrian/photos/VID_48733.mp4"
    ]
  }
]
```
