### PR TITLE
Add verbose and stdout flag  

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,13 @@ package main
 import (
 	_ "embed"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"time"
+
 	set "github.com/deckarep/golang-set/v2"
 	"github.com/m-manu/go-find-duplicates/bytesutil"
 	"github.com/m-manu/go-find-duplicates/entity"
@@ -14,12 +21,6 @@ import (
 	"github.com/m-manu/go-find-duplicates/service"
 	"github.com/m-manu/go-find-duplicates/utils"
 	flag "github.com/spf13/pflag"
-	"os"
-	"path/filepath"
-	"runtime"
-	"runtime/debug"
-	"strings"
-	"time"
 )
 
 // Exit codes for this program
@@ -49,6 +50,7 @@ var flags struct {
 	getParallelism   func() int
 	isThorough       func() bool
 	getVersion       func() bool
+	getVerbose       func() bool
 }
 
 func setupExclusionsOpt() {
@@ -141,6 +143,13 @@ func setupOutputModeOpt() {
 	}
 }
 
+func setupVerboseOpt() {
+	verbosePtr := flag.Bool("verbose", false, "verbose output")
+	flags.getVerbose = func() bool {
+		return *verbosePtr
+	}
+}
+
 func setupVersionOpt() {
 	versionPtr := flag.Bool("version", false,
 		"Display version ("+version+") and exit (useful for incorporating this in scripts)")
@@ -210,6 +219,7 @@ func setupFlags() {
 	setupParallelismOpt()
 	setupThoroughOpt()
 	setupUsage()
+	setupVerboseOpt()
 	setupVersionOpt()
 }
 
@@ -252,6 +262,9 @@ func main() {
 		fmt.Println(version)
 		os.Exit(exitCodeSuccess)
 		return
+	}
+	if !flags.getVerbose() {
+		fmte.Off()
 	}
 	directories := readDirectories()
 	outputMode := flags.getOutputMode()

--- a/service/find_duplicates.go
+++ b/service/find_duplicates.go
@@ -2,14 +2,15 @@ package service
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
 	set "github.com/deckarep/golang-set/v2"
 	"github.com/m-manu/go-find-duplicates/bytesutil"
 	"github.com/m-manu/go-find-duplicates/entity"
 	"github.com/m-manu/go-find-duplicates/fmte"
 	"github.com/m-manu/go-find-duplicates/utils"
-	"sync"
-	"sync/atomic"
-	"time"
 )
 
 // FindDuplicates finds duplicate files in a given set of directories and matching criteria


### PR DESCRIPTION
##  Why
see https://github.com/m-manu/go-find-duplicates/issues/10 

I add two flags  `--verbose` and `--stdout`, and the default value is both false.

if `--verbose` **was not enabled**.   the fmte.Off() will called, and disable the running log print.

if `--stdout` was enabled,  the program will not create a file to report, it will print the report to stdout.

## How

```
./go-find-duplicates ./ 
./go-find-duplicates --verbose ./
./go-find-duplicates --stdout  ./
./go-find-duplicates --stdout  -o json ./
./go-find-duplicates --stdout  -o csv ./
```

## What changed
the only changed behavior is `--verbose` is default false
so there is no running log now

```
./go-find-duplicates --verbose ./
Scanning 1 directories...
Done. Found 8 files of total size 3.17 MiB.
Finding potential duplicates... 
No duplicates found!
```
 



